### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Joel Gaehwiler <joel.gaehwiler@gmail.com>
 maintainer=Joel Gaehwiler <joel.gaehwiler@gmail.com>
 sentence=MQTT library for Arduino based on the Eclipse Paho projects.
 paragraph=This library bundles the Embedded MQTT C/C++ Client library of the Eclipse Paho project and adds a thin wrapper to get an Arduino like API. Additionally there is an drop-in alternative for the Arduino Yùn that uses a python based client on the linux processor and a binary interface to lower program space usage on the Arduino side.
+category=Communication
 url=https://github.com/256dpi/arduino-mqtt
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library MQTT is not valid. Setting to
'Uncategorized'` warning in Arduino IDE 1.6.6.