### PR TITLE
wrap callback in MQTTClient class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This library is an alternative to the [pubsubclient](https://github.com/knollear
 
 The following examples show how you can use the library with various Arduino compatible hardware:
 
-- [Arduino Yun (MQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_MQTTClient/ArduinoYun_MQTTClient.ino)
-- [Arduino Yun (YunMQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino) ([SSL](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient_SSL/ArduinoYun_YunMQTTClient_SSL.ino))
+- [Arduino Yun/Yun Shield (MQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_MQTTClient/ArduinoYun_MQTTClient.ino)
+- [Arduino Yun/Yun Shield (YunMQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino) ([SSL Yun firmware >= 1.6.2](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient_SSL/ArduinoYun_YunMQTTClient_SSL.ino))
 - [Arduino Ethernet Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino)
 - [Arduino WiFi Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino)
 - [Adafruit HUZZAH ESP8266](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino) ([SSL](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266_SSL/AdafruitHuzzahESP8266_SSL.ino))

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -20,7 +20,7 @@ void messageReceived(String topic, String payload, char * bytes, unsigned int le
 class MQTTClient {
 private:
   Network network;
-  MQTT::Client<Network, Timer, MQTT_BUFFER_SIZE, 0> * client;
+  MQTT::Client<MQTTClient, Network, Timer, MQTT_BUFFER_SIZE, 0> * client;
   MQTTPacket_connectData options;
   const char * hostname;
   int port;
@@ -28,6 +28,7 @@ public:
   MQTTClient();
   boolean begin(const char * hostname, Client& client);
   boolean begin(const char * hostname, int port, Client& client);
+  MQTTClient callback(MQTT::MessageData& messageData);
   void setWill(const char * topic);
   void setWill(const char * topic, const char * payload);
   boolean connect(const char * clientId);

--- a/src/YunMQTTClient.cpp
+++ b/src/YunMQTTClient.cpp
@@ -1,5 +1,3 @@
-#ifdef ARDUINO_AVR_YUN
-
 #include "YunMQTTClient.h"
 
 #include <FileIO.h>
@@ -188,5 +186,3 @@ void YunMQTTClient::disconnect() {
   // send disconnect request
   this->process.print(F("d;\n"));
 }
-
-#endif //ARDUINO_AVR_YUN

--- a/src/YunMQTTClient.h
+++ b/src/YunMQTTClient.h
@@ -1,8 +1,6 @@
 #ifndef YUN_MQTT_CLIENT_H
 #define YUN_MQTT_CLIENT_H
 
-#ifdef ARDUINO_AVR_YUN
-
 #include <Arduino.h>
 #include <Bridge.h>
 
@@ -41,5 +39,4 @@ public:
   void disconnect();
 };
 
-#endif //ARDUINO_AVR_YUN
 #endif //YUN_MQTT_CLIENT_H

--- a/src/lib/FP.h
+++ b/src/lib/FP.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 
+ * Copyright (c) 2013, 2014
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -169,7 +169,7 @@ public:
         if( 0 != c_callback ) {
             return obj_callback ? (obj_callback->*method_callback)(arg) : (*c_callback)(arg);
         }
-        return (retT)0;
+        // return (retT)0;
     }
 
     /** Determine if an callback is currently hooked


### PR DESCRIPTION
Now the `messageArrived` is part of the MQTTClient class, in order to works I had to edit the template's style of the MQTTClient lib and a little change to the foot print lib.

This is **only a proposal** that not improves the performances but  only the correctness of the code because is not safe to leave the `messageArrived` as global function.

In the feature could be interesting to use the the feature of the paho library to attach a different callback to every subscribe event.

@256dpi you think that could be useful?