### PR TITLE
More Advanced Publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ boolean publish(String topic, String payload);
 boolean publish(const char * topic, String payload);
 boolean publish(const char * topic, const char * payload);
 boolean publish(const char * topic, char * payload, unsigned int length);
+boolean publish(MQTTMessage * message)
 ```
+
+- The last function can be used to publish messages with more low level attributes like `retained`.
 
 Subscribe to a topic:
 

--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -87,6 +87,17 @@ boolean MQTTClient::publish(const char * topic, char * payload, unsigned int len
   return client->publish(topic, message) == MQTT::SUCCESS;
 }
 
+boolean MQTTClient::publish(MQTTMessage * message) {
+  MQTT::Message _message;
+  _message.qos = MQTT::QOS0;
+  _message.retained = message->retained;
+  _message.dup = false;
+  _message.payload = message->payload;
+  _message.payloadlen = message->length;
+
+  return client->publish(message->topic, _message) == MQTT::SUCCESS;
+}
+
 boolean MQTTClient::subscribe(String topic) {
   return this->subscribe(topic.c_str());
 }

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -15,6 +15,13 @@
 #include "Network.h"
 #include "Timer.h"
 
+typedef struct {
+    char * topic;
+    char * payload;
+    unsigned int length;
+    boolean retained;
+} MQTTMessage;
+
 void messageReceived(String topic, String payload, char * bytes, unsigned int length);
 
 class MQTTClient {
@@ -37,6 +44,7 @@ public:
   boolean publish(const char * topic, String payload);
   boolean publish(const char * topic, const char * payload);
   boolean publish(const char * topic, char * payload, unsigned int length);
+  boolean publish(MQTTMessage * message);
   boolean subscribe(String topic);
   boolean subscribe(const char * topic);
   boolean unsubscribe(String topic);


### PR DESCRIPTION
This adds the method `void publish(MQTTMessage * message);` that allows publishing messages using the new `MQTTMessage` struct. Currently the struct only allows to set the `retained` flag but may also allow setting the quality of service in later versions.

I didn't want add another normal functions as these are considered short-hand functions and setting the retained flag is more advanced.

Solves #27.

@gibix I created a custom struct rather than using the internal structure to expose a nicer API. In the future we might use the same structure also in the `messageReceived` callback and maybe add convenience functions like `String string()` etc.