### PR TITLE
Add setTls API for Yun client to support TLS connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library is an alternative to the [pubsubclient](https://github.com/knollear
 The following examples show how you can use the library with various Arduino compatible hardware:
 
 - [Arduino Yun (MQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_MQTTClient/ArduinoYun_MQTTClient.ino)
-- [Arduino Yun (YunMQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino)
+- [Arduino Yun (YunMQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino) ([SSL](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient_SSL/ArduinoYun_YunMQTTClient_SSL.ino))
 - [Arduino Ethernet Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino)
 - [Arduino WiFi Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino)
 - [Adafruit HUZZAH ESP8266](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino) ([SSL](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266_SSL/AdafruitHuzzahESP8266_SSL.ino))

--- a/examples/ArduinoYun_YunMQTTClient_SSL/ArduinoYun_YunMQTTClient_SSL.ino
+++ b/examples/ArduinoYun_YunMQTTClient_SSL/ArduinoYun_YunMQTTClient_SSL.ino
@@ -1,0 +1,63 @@
+// This example uses an Arduino Yun and the
+// YunMQTTClient to connect to shiftr.io.
+//
+// The YunMQTTClient uses a Linux side python
+// script to manage the connection which results
+// in less program space and memory used on the Arduino.
+//
+// You can check on your device after a successful
+// connection here: https://shiftr.io/try.
+//
+// by Joël Gähwiler
+// https://github.com/256dpi/arduino-mqtt
+
+#include <Bridge.h>
+#include <YunMQTTClient.h>
+
+YunMQTTClient client;
+
+unsigned long lastMillis = 0;
+
+void setup() {
+  Bridge.begin();
+  Serial.begin(9600);
+  client.begin("broker.shiftr.io", 8883); // MQTT brokers usually use port 8883 for secure connections
+  client.setTls("/etc/ssl/certs/AddTrust_External_Root.crt"); // select the CA for the broker
+
+  connect();
+}
+
+void connect() {
+  Serial.print("connecting...");
+  while (!client.connect("arduino", "try", "try")) {
+    Serial.print(".");
+    delay(1000);
+  }
+
+  Serial.println("\nconnected!");
+
+  client.subscribe("/example");
+  // client.unsubscribe("/example");
+}
+
+void loop() {
+  client.loop();
+
+  if(!client.connected()) {
+    connect();
+  }
+
+  // publish a message roughly every second.
+  if(millis() - lastMillis > 1000) {
+    lastMillis = millis();
+    client.publish("/hello", "world");
+  }
+}
+
+void messageReceived(String topic, String payload, char * bytes, unsigned int length) {
+  Serial.print("incoming: ");
+  Serial.print(topic);
+  Serial.print(" - ");
+  Serial.print(payload);
+  Serial.println();
+}

--- a/src/YunMQTTClient.cpp
+++ b/src/YunMQTTClient.cpp
@@ -36,6 +36,10 @@ void YunMQTTClient::setWill(const char * topic, const char * payload) {
   this->willPayload = payload;
 }
 
+void YunMQTTClient::setTls(const char * caCerts) {
+  this->tlsCaCerts = caCerts;
+}
+
 boolean YunMQTTClient::connect(const char * clientId) {
   return this->connect(clientId, "", "");
 }
@@ -59,6 +63,13 @@ boolean YunMQTTClient::connect(const char * clientId, const char * username, con
     this->process.print(';');
     this->process.print(this->willPayload);
     this->process.print('\n');
+  }
+
+  // set TLS if available
+  if(strlen(this->tlsCaCerts) > 0) {
+    this->process.print("t:");
+    this->process.print(this->tlsCaCerts);
+    this->process.print(";\n");
   }
 
   // send connect request

--- a/src/YunMQTTClient.h
+++ b/src/YunMQTTClient.h
@@ -15,6 +15,7 @@ private:
   int port;
   const char * willTopic = "";
   const char * willPayload = "";
+  const char * tlsCaCerts = "";
   boolean alive = false;
   boolean updateBridge();
 public:
@@ -23,6 +24,7 @@ public:
   boolean begin(const char * hostname, int port);
   void setWill(const char * topic);
   void setWill(const char * topic, const char * payload);
+  void setTls(const char * caCerts);
   boolean connect(const char * clientId);
   boolean connect(const char * clientId, const char* username, const char* password);
   void publish(String topic);

--- a/yun/abi.md
+++ b/yun/abi.md
@@ -8,6 +8,7 @@ The following commands are exchanged between the python script and the arduino l
 ---|-------------|------------------------------------
 <- | boot        | `b;`
 -> | will        | `w:topic:payload_len;(payload)`
+-> | tls         | `t:ca_certs;`
 -> | connect     | `c:host:port:id:(user):(pass);`
 <- | approved    | `a;`
 <- | rejected    | `r;`

--- a/yun/bridge.py
+++ b/yun/bridge.py
@@ -11,6 +11,7 @@ class Bridge:
         self.client = None
         self.will_topic = ""
         self.will_payload = ""
+        self.tls_ca_certs = ""
         self.stopped = False
 
     # Bridge Callbacks
@@ -29,6 +30,8 @@ class Bridge:
         remaining = segments[1:]
         if cmd == 'w':
             self.do_will(remaining)
+        elif cmd == 't':
+            self.do_tls(remaining)
         elif cmd == 'c':
             self.do_connect(remaining)
         elif cmd == 's':
@@ -48,6 +51,9 @@ class Bridge:
         self.will_topic = args[0]
         self.will_payload = self.read_chunk(int(args[1]))
 
+    def do_tls(self, args):
+        self.tls_ca_certs = args[0]
+
     def do_connect(self, args):
         self.client = mqtt.Client(args[2])
         self.client.on_connect = self.on_connect
@@ -58,6 +64,8 @@ class Bridge:
         if len(self.will_topic) > 0:
             self.client.will_set(self.will_topic, self.will_payload)
         try:
+            if len(self.tls_ca_certs) > 0:
+                self.client.tls_set(self.tls_ca_certs)
             self.client.connect(args[0], int(args[1]))
             self.client.loop_start()
         except:


### PR DESCRIPTION
This allows the Yun to connect to brokers with TLS/SSL. The new 1.6.2 Yun image bundles CA certs. in `/etc/ssl/certs/`.

Another option would be to create a new `YunMQTTSSLClient` which accepts the CA as a constructor argument.

cc/ @lorenzoromagnoli

(Note: I'm aware there's an open discussion in #34 to remove YunMQTTClient support) 