### PR TITLE
Unlock Yun Shield support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: generic
 env:
   global:
-    - IDE_VERSION=1.6.8
+    - IDE_VERSION=1.6.9
   matrix:
     - EXAMPLE="AdafruitHuzzahESP8266" BOARD="esp8266:esp8266:huzzah:FlashSize=4M3M,CpuFrequency=80"
     - EXAMPLE="AdafruitHuzzahESP8266_SSL" BOARD="esp8266:esp8266:huzzah:FlashSize=4M3M,CpuFrequency=80"

--- a/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino
+++ b/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino
@@ -20,20 +20,20 @@ unsigned long lastMillis = 0;
 
 void setup() {
   Bridge.begin();
-  Serial.begin(9600);
+  SerialUSB.begin(9600);
   client.begin("broker.shiftr.io");
 
   connect();
 }
 
 void connect() {
-  Serial.print("connecting...");
+  SerialUSB.print("connecting...");
   while (!client.connect("arduino", "try", "try")) {
-    Serial.print(".");
+    SerialUSB.print(".");
     delay(1000);
   }
 
-  Serial.println("\nconnected!");
+  SerialUSB.println("\nconnected!");
 
   client.subscribe("/example");
   // client.unsubscribe("/example");
@@ -54,9 +54,9 @@ void loop() {
 }
 
 void messageReceived(String topic, String payload, char * bytes, unsigned int length) {
-  Serial.print("incoming: ");
-  Serial.print(topic);
-  Serial.print(" - ");
-  Serial.print(payload);
-  Serial.println();
+  SerialUSB.print("incoming: ");
+  SerialUSB.print(topic);
+  SerialUSB.print(" - ");
+  SerialUSB.print(payload);
+  SerialUSB.println();
 }

--- a/src/YunMQTTClient.cpp
+++ b/src/YunMQTTClient.cpp
@@ -1,6 +1,6 @@
-#ifdef ARDUINO_AVR_YUN
-
 #include "YunMQTTClient.h"
+
+#ifdef YUN_MQTT_CLIENT_ENABLED
 
 #include <FileIO.h>
 
@@ -178,4 +178,4 @@ void YunMQTTClient::disconnect() {
   this->process.print("d;\n");
 }
 
-#endif //ARDUINO_AVR_YUN
+#endif //YUN_MQTT_CLIENT_ENABLED

--- a/src/YunMQTTClient.h
+++ b/src/YunMQTTClient.h
@@ -1,7 +1,14 @@
 #ifndef YUN_MQTT_CLIENT_H
 #define YUN_MQTT_CLIENT_H
 
-#ifdef ARDUINO_AVR_YUN
+
+#if defined(SERIAL_PORT_LINUXBRIDGE) || defined(SERIAL_PORT_HARDWARE) || \
+    defined(SERIAL_PORT_HARDWARE_OPEN) || defined(__AVR_ATmega32U4__) || \
+    defined(ARDUINO_AVR_YUN)
+#define YUN_MQTT_CLIENT_ENABLED 1
+#endif
+
+#ifdef YUN_MQTT_CLIENT_ENABLED
 
 #include <Arduino.h>
 #include <Bridge.h>
@@ -39,5 +46,5 @@ public:
   void disconnect();
 };
 
-#endif //ARDUINO_AVR_YUN
+#endif //YUN_MQTT_CLIENT_ENABLED
 #endif //YUN_MQTT_CLIENT_H


### PR DESCRIPTION
This unlocks support for the new [Yun Shield](https://www.arduino.cc/en/Main/ArduinoYunShield) in `YunMQTTClient`.

Changes to the Bridge library were added in:
 * https://github.com/arduino-libraries/Bridge/commit/636c541a213ce6e72b6f0aa3e8ab1b37679a63e4
 * https://github.com/arduino-libraries/Bridge/commit/4c9b6b11cbc5756abcd3ced0d5666afca4240ee0

cc/ @lorenzoromagnoli