### PR TITLE
add yun shield support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This library is an alternative to the [pubsubclient](https://github.com/knollear
 
 The following examples show how you can use the library with various Arduino compatible hardware:
 
-- [Arduino Yun (MQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_MQTTClient/ArduinoYun_MQTTClient.ino)
-- [Arduino Yun (YunMQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino) ([SSL](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient_SSL/ArduinoYun_YunMQTTClient_SSL.ino))
+- [Arduino Yun/Yun-Shield (MQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_MQTTClient/ArduinoYun_MQTTClient.ino)
+- [Arduino Yun/Yun-Shield (YunMQTTClient)](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient/ArduinoYun_YunMQTTClient.ino) ([SSL](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun_YunMQTTClient_SSL/ArduinoYun_YunMQTTClient_SSL.ino))
 - [Arduino Ethernet Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino)
 - [Arduino WiFi Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino)
 - [Adafruit HUZZAH ESP8266](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino) ([SSL](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266_SSL/AdafruitHuzzahESP8266_SSL.ino))

--- a/src/YunMQTTClient.cpp
+++ b/src/YunMQTTClient.cpp
@@ -1,5 +1,3 @@
-#ifdef ARDUINO_AVR_YUN
-
 #include "YunMQTTClient.h"
 
 #include <FileIO.h>
@@ -188,5 +186,3 @@ void YunMQTTClient::disconnect() {
   // send disconnect request
   this->process.print(F("d;\n"));
 }
-
-#endif //ARDUINO_AVR_YUN

--- a/src/YunMQTTClient.h
+++ b/src/YunMQTTClient.h
@@ -1,8 +1,6 @@
 #ifndef YUN_MQTT_CLIENT_H
 #define YUN_MQTT_CLIENT_H
 
-#ifdef ARDUINO_AVR_YUN
-
 #include <Arduino.h>
 #include <Bridge.h>
 
@@ -41,5 +39,4 @@ public:
   void disconnect();
 };
 
-#endif //ARDUINO_AVR_YUN
 #endif //YUN_MQTT_CLIENT_H


### PR DESCRIPTION
Simple PR to support the [yun shield](https://www.arduino.cc/en/Main/ArduinoYunShield).
The sketch for the yun shield is not compiled for the yun core, but for the board at the shield is attached (uno, zero, etc). For this reason we have to remove the compile macro that checks the core.
This will not impact on user interface.