### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Other shields and boards should work if they also provide a [Client](https://www
 The following example uses an Arduino Yun and the MQTTClient to connect to shiftr.io. You can check on your device after a successful connection here: <https://shiftr.io/try>.
 
 ```c++
-#include <Bridge.h>
-#include <YunClient.h>
-#include <MQTTClient.h>
+# include <Bridge.h>
+# include <YunClient.h>
+# include <MQTTClient.h>
 
 YunClient net;
 MQTTClient client;


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
