### PR TITLE
fix warnings

### DIFF
--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -1,6 +1,8 @@
 #ifndef MQTT_CLIENT_H
 #define MQTT_CLIENT_H
 
+#include <string.h>
+
 #include <Arduino.h>
 #include <Client.h>
 #include <Stream.h>
@@ -18,7 +20,7 @@ typedef struct {
   MQTTClientCallbackAdvanced advanced = nullptr;
 } MQTTClientCallback;
 
-static void MQTTClientHandler(lwmqtt_client_t *client, void *ref, lwmqtt_string_t topic, lwmqtt_message_t message) {
+static void MQTTClientHandler(lwmqtt_client_t * /*client */, void *ref, lwmqtt_string_t topic, lwmqtt_message_t message) {
   // get callback
   auto cb = (MQTTClientCallback *)ref;
 
@@ -76,7 +78,7 @@ class MQTTClient {
   lwmqtt_arduino_network_t network = {nullptr};
   lwmqtt_arduino_timer_t timer1 = {0};
   lwmqtt_arduino_timer_t timer2 = {0};
-  lwmqtt_client_t client = {0};
+  lwmqtt_client_t client;
 
   bool _connected = false;
   lwmqtt_return_code_t _returnCode = (lwmqtt_return_code_t)0;
@@ -84,6 +86,7 @@ class MQTTClient {
 
  public:
   explicit MQTTClient(int bufSize = 128) {
+    memset(&client, 0, sizeof(client));
     this->bufSize = (size_t)bufSize;
     this->readBuf = (uint8_t *)malloc((size_t)bufSize + 1);
     this->writeBuf = (uint8_t *)malloc((size_t)bufSize);


### PR DESCRIPTION
Fixes the following warnings:

MQTTClient.h:21:13: warning: unused parameter 'client' [-Wunused-parameter]
 static void MQTTClientHandler(lwmqtt_client_t *client, void *ref, lwmqtt_string_t topic, lwmqtt_message_t message) {
             ^
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::keep_alive_interval' [-Wmissing-field-initializers]
   lwmqtt_client_t client = {0};
                              ^
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::pong_pending' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::write_buf_size' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::read_buf_size' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::write_buf' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::read_buf' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::callback' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::callback_ref' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::network' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::network_read' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::network_write' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::keep_alive_timer' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::command_timer' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::timer_set' [-Wmissing-field-initializers]
MQTTClient.h:79:30: warning: missing initializer for member 'lwmqtt_client_t::timer_get' [-Wmissing-field-initializers]