### PR TITLE
change boolean to bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ void setOptions(int keepAlive, bool cleanSession, int timeout);
 Connect to broker using the supplied client id and an optional username and password:
 
 ```c++
-boolean connect(const char clientId[]);
-boolean connect(const char clientId[], const char username[]);
-boolean connect(const char clientId[], const char username[], const char password[]);
+bool connect(const char clientId[]);
+bool connect(const char clientId[], const char username[]);
+bool connect(const char clientId[], const char username[], const char password[]);
 ```
 
 - This functions returns a boolean that indicates if the connection has been established successfully.
@@ -159,38 +159,38 @@ boolean connect(const char clientId[], const char username[], const char passwor
 Publishes a message to the broker with an optional payload:
 
 ```c++
-boolean publish(const String &topic);
-boolean publish(const char topic[]);
-boolean publish(const String &topic, const String &payload);
-boolean publish(const String &topic, const String &payload, bool retained, int qos);
-boolean publish(const char topic[], const String &payload);
-boolean publish(const char topic[], const String &payload, bool retained, int qos);
-boolean publish(const char topic[], const char payload[]);
-boolean publish(const char topic[], const char payload[], bool retained, int qos);
-boolean publish(const char topic[], const char payload[], int length);
-boolean publish(const char topic[], const char payload[], int length, bool retained, int qos);
+bool publish(const String &topic);
+bool publish(const char topic[]);
+bool publish(const String &topic, const String &payload);
+bool publish(const String &topic, const String &payload, bool retained, int qos);
+bool publish(const char topic[], const String &payload);
+bool publish(const char topic[], const String &payload, bool retained, int qos);
+bool publish(const char topic[], const char payload[]);
+bool publish(const char topic[], const char payload[], bool retained, int qos);
+bool publish(const char topic[], const char payload[], int length);
+bool publish(const char topic[], const char payload[], int length, bool retained, int qos);
 ```
 
 Subscribe to a topic:
 
 ```c++
-boolean subscribe(const String &topic);
-boolean subscribe(const String &topic, int qos); 
-boolean subscribe(const char topic[]);
-boolean subscribe(const char topic[], int qos);
+bool subscribe(const String &topic);
+bool subscribe(const String &topic, int qos); 
+bool subscribe(const char topic[]);
+bool subscribe(const char topic[], int qos);
 ```
 
 Unsubscribe from a topic:
 
 ```c++
-boolean unsubscribe(const String &topic);
-boolean unsubscribe(const char topic[]);
+bool unsubscribe(const String &topic);
+bool unsubscribe(const char topic[]);
 ```
 
 Sends and receives packets:
 
 ```c++
-boolean loop();
+bool loop();
 ```
 
 - This function should be called in every `loop`.
@@ -198,7 +198,7 @@ boolean loop();
 Check if the client is currently connected:
 
 ```c++
-boolean connected();
+bool connected();
 ```
 
 Access low-level information for debugging:
@@ -211,5 +211,5 @@ lwmqtt_return_code_t returnCode();
 Disconnect from the broker:
 
 ```c++
-boolean disconnect();
+bool disconnect();
 ```

--- a/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
+++ b/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
@@ -37,7 +37,7 @@ void setup() {
 
 void connect() {
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   Serial.print("connecting to cellular network ...");
 

--- a/examples/ArduinoMKRGSM1400_SSL/ArduinoMKRGSM1400_SSL.ino
+++ b/examples/ArduinoMKRGSM1400_SSL/ArduinoMKRGSM1400_SSL.ino
@@ -39,7 +39,7 @@ void setup() {
 
 void connect() {
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   Serial.print("connecting to cellular network ...");
 

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -158,11 +158,11 @@ class MQTTClient {
     this->timeout = (uint32_t)timeout;
   }
 
-  boolean connect(const char clientId[]) { return this->connect(clientId, nullptr, nullptr); }
+  bool connect(const char clientId[]) { return this->connect(clientId, nullptr, nullptr); }
 
-  boolean connect(const char clientId[], const char username[]) { return this->connect(clientId, username, nullptr); }
+  bool connect(const char clientId[], const char username[]) { return this->connect(clientId, username, nullptr); }
 
-  boolean connect(const char clientId[], const char username[], const char password[]) {
+  bool connect(const char clientId[], const char username[], const char password[]) {
     // close left open connection if still connected
     if (this->connected()) {
       this->close();
@@ -209,35 +209,35 @@ class MQTTClient {
     return true;
   }
 
-  boolean publish(const String &topic) { return this->publish(topic.c_str(), ""); }
+  bool publish(const String &topic) { return this->publish(topic.c_str(), ""); }
 
-  boolean publish(const char topic[]) { return this->publish(topic, ""); }
+  bool publish(const char topic[]) { return this->publish(topic, ""); }
 
-  boolean publish(const String &topic, const String &payload) { return this->publish(topic.c_str(), payload.c_str()); }
+  bool publish(const String &topic, const String &payload) { return this->publish(topic.c_str(), payload.c_str()); }
 
-  boolean publish(const String &topic, const String &payload, bool retained, int qos) {
+  bool publish(const String &topic, const String &payload, bool retained, int qos) {
     return this->publish(topic.c_str(), payload.c_str(), retained, qos);
   }
 
-  boolean publish(const char topic[], const String &payload) { return this->publish(topic, payload.c_str()); }
+  bool publish(const char topic[], const String &payload) { return this->publish(topic, payload.c_str()); }
 
-  boolean publish(const char topic[], const String &payload, bool retained, int qos) {
+  bool publish(const char topic[], const String &payload, bool retained, int qos) {
     return this->publish(topic, payload.c_str(), retained, qos);
   }
 
-  boolean publish(const char topic[], const char payload[]) {
+  bool publish(const char topic[], const char payload[]) {
     return this->publish(topic, (char *)payload, (int)strlen(payload));
   }
 
-  boolean publish(const char topic[], const char payload[], bool retained, int qos) {
+  bool publish(const char topic[], const char payload[], bool retained, int qos) {
     return this->publish(topic, (char *)payload, (int)strlen(payload), retained, qos);
   }
 
-  boolean publish(const char topic[], const char payload[], int length) {
+  bool publish(const char topic[], const char payload[], int length) {
     return this->publish(topic, payload, length, false, 0);
   }
 
-  boolean publish(const char topic[], const char payload[], int length, bool retained, int qos) {
+  bool publish(const char topic[], const char payload[], int length, bool retained, int qos) {
     // return immediately if not connected
     if (!this->connected()) {
       return false;
@@ -259,13 +259,13 @@ class MQTTClient {
     return true;
   }
 
-  boolean subscribe(const String &topic) { return this->subscribe(topic.c_str()); }
+  bool subscribe(const String &topic) { return this->subscribe(topic.c_str()); }
 
-  boolean subscribe(const String &topic, int qos) { return this->subscribe(topic.c_str(), qos); }
+  bool subscribe(const String &topic, int qos) { return this->subscribe(topic.c_str(), qos); }
 
-  boolean subscribe(const char topic[]) { return this->subscribe(topic, 0); }
+  bool subscribe(const char topic[]) { return this->subscribe(topic, 0); }
 
-  boolean subscribe(const char topic[], int qos) {
+  bool subscribe(const char topic[], int qos) {
     // return immediately if not connected
     if (!this->connected()) {
       return false;
@@ -280,9 +280,9 @@ class MQTTClient {
     return true;
   }
 
-  boolean unsubscribe(const String &topic) { return this->unsubscribe(topic.c_str()); }
+  bool unsubscribe(const String &topic) { return this->unsubscribe(topic.c_str()); }
 
-  boolean unsubscribe(const char topic[]) {
+  bool unsubscribe(const char topic[]) {
     // return immediately if not connected
     if (!this->connected()) {
       return false;
@@ -297,7 +297,7 @@ class MQTTClient {
     return true;
   }
 
-  boolean loop() {
+  bool loop() {
     // return immediately if not connected
     if (!this->connected()) {
       return false;
@@ -323,7 +323,7 @@ class MQTTClient {
     return true;
   }
 
-  boolean connected() {
+  bool connected() {
     // a client is connected if the network is connected, a client is available and
     // the connection has been properly initiated
     return this->netClient != nullptr && this->netClient->connected() == 1 && this->_connected;
@@ -333,7 +333,7 @@ class MQTTClient {
 
   lwmqtt_return_code_t returnCode() { return this->_returnCode; }
 
-  boolean disconnect() {
+  bool disconnect() {
     // return immediately if not connected anymore
     if (!this->connected()) {
       return false;
@@ -349,7 +349,7 @@ class MQTTClient {
   }
 
  private:
-  boolean close() {
+  bool close() {
     // set flag
     this->_connected = false;
 


### PR DESCRIPTION
Reasons:
- the library use both types `publish(const char topic[], const String &payload, bool retained, int qos);` , so get rid of one
- bool is the common type for boolean
- discussion on arduino project: https://github.com/arduino/Arduino/issues/4673
