### PR TITLE
Fix for broken examples; Info for pio installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This library bundles the [lwmqtt](https://github.com/256dpi/lwmqtt) MQTT 3.1.1 c
 
 Download the latest version from the [release](https://github.com/256dpi/arduino-mqtt/releases) section. Or even better use the builtin Library Manager in the Arduino IDE and search for "MQTT".
 
+To install the latest version when working with
+[platformio](https://platformio.org),
+use `pio lib install 617` or visit
+the [library page](https://platformio.org/lib/show/617/MQTT/installation).
+
 ## Compatibility
 
 The following examples show how you can use the library with various Arduino compatible hardware:

--- a/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
+++ b/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
@@ -6,7 +6,6 @@
 //
 // by Joël Gähwiler
 // https://github.com/256dpi/arduino-mqtt
-
 #include <WiFi.h>
 #include <MQTTClient.h>
 
@@ -18,6 +17,33 @@ MQTTClient client;
 
 unsigned long lastMillis = 0;
 
+// Callback for additional processing of incoming messages
+void messageReceived(String &topic, String &payload) {
+  Serial.println("incoming: " + topic + " - " + payload);
+}
+
+// A helper routine to ensure the device is connected
+// to the WLAN and the MQTT broker.
+// Subscribe to topic "/hello"
+void connect() {
+  Serial.print("checking wifi...");
+  while (WiFi.status() != WL_CONNECTED) {
+    Serial.print(".");
+    delay(1000);
+  }
+
+  Serial.print("\nconnecting...");
+  while (!client.connect("client-id", "user", "password")) {
+    Serial.print(".");
+    delay(1000);
+  }
+
+  Serial.println("\nconnected!");
+
+  client.subscribe("/hello");
+  // client.unsubscribe("/hello");
+}
+
 void setup() {
   Serial.begin(115200);
   WiFi.begin(ssid, pass);
@@ -28,25 +54,6 @@ void setup() {
   client.onMessage(messageReceived);
 
   connect();
-}
-
-void connect() {
-  Serial.print("checking wifi...");
-  while (WiFi.status() != WL_CONNECTED) {
-    Serial.print(".");
-    delay(1000);
-  }
-
-  Serial.print("\nconnecting...");
-  while (!client.connect("arduino", "try", "try")) {
-    Serial.print(".");
-    delay(1000);
-  }
-
-  Serial.println("\nconnected!");
-
-  client.subscribe("/hello");
-  // client.unsubscribe("/hello");
 }
 
 void loop() {
@@ -64,6 +71,3 @@ void loop() {
   }
 }
 
-void messageReceived(String &topic, String &payload) {
-  Serial.println("incoming: " + topic + " - " + payload);
-}

--- a/examples/ESP32DevelopmentBoard_SSL/ESP32DevelopmentBoard_SSL.ino
+++ b/examples/ESP32DevelopmentBoard_SSL/ESP32DevelopmentBoard_SSL.ino
@@ -6,7 +6,6 @@
 //
 // by Joël Gähwiler
 // https://github.com/256dpi/arduino-mqtt
-
 #include <WiFiClientSecure.h>
 #include <MQTTClient.h>
 
@@ -18,20 +17,14 @@ MQTTClient client;
 
 unsigned long lastMillis = 0;
 
-void setup() {
-  Serial.begin(115200);
-  WiFi.begin(ssid, pass);
-
-  // Note: Local domain names (e.g. "Computer.local" on OSX) are not supported by Arduino.
-  // You need to set the IP address directly.
-  //
-  // MQTT brokers usually use port 8883 for secure connections.
-  client.begin("broker.shiftr.io", 8883, net);
-  client.onMessage(messageReceived);
-
-  connect();
+// Callback for additional processing of incoming messages
+void messageReceived(String &topic, String &payload) {
+  Serial.println("incoming: " + topic + " - " + payload);
 }
 
+// A helper routine to ensure the device is connected
+// to the WLAN and the MQTT broker.
+// Subscribe to topic "/hello"
 void connect() {
   Serial.print("checking wifi...");
   while (WiFi.status() != WL_CONNECTED) {
@@ -40,7 +33,7 @@ void connect() {
   }
 
   Serial.print("\nconnecting...");
-  while (!client.connect("arduino", "try", "try")) {
+  while (!client.connect("client-id", "user", "password")) {
     Serial.print(".");
     delay(1000);
   }
@@ -49,6 +42,20 @@ void connect() {
 
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
+}
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, pass);
+
+  // Note: Local domain names (e.g. "Computer.local" on OSX) are not supported by Arduino.
+  // You need to set the IP address directly.
+  //
+  // MQTT brokers usually use port 8883 for secure connections
+  client.begin("broker.shiftr.io", 8883, net);
+  client.onMessage(messageReceived);
+
+  connect();
 }
 
 void loop() {
@@ -66,6 +73,3 @@ void loop() {
   }
 }
 
-void messageReceived(String &topic, String &payload) {
-  Serial.println("incoming: " + topic + " - " + payload);
-}


### PR DESCRIPTION
Hey Joël,

this PR:
- fixes the code examples for the ESP32 dev board which couldn't be compiled (the functions have no declared prototypes, hence must be declared before invoked).
- adds a reference to the [platformio library page](https://platformio.org/lib/show/617/MQTT/installation) in the README since it's quite tricky to find the library in the pio index (missed it at first).
   
Thanks for the library!