### PR TITLE
Add main MQTT.h header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCE_FILES
     examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
     examples/ESP32DevelopmentBoard_SSL/ESP32DevelopmentBoard_SSL.ino
     src/lwmqtt
+    src/MQTT.h
     src/MQTTClient.h
     src/system.cpp
     src/system.h)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Other shields and boards should also work if they provide a [Client](https://www
 The following example uses an Arduino MKR1000 to connect to shiftr.io. You can check on your device after a successful connection here: https://shiftr.io/try.
 
 ```c++
-#include <MQTTClient.h>
+#include <MQTT.h>
 #include <SPI.h>
 #include <WiFi101.h>
 

--- a/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
+++ b/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
@@ -8,7 +8,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <ESP8266WiFi.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char ssid[] = "ssid";
 const char pass[] = "pass";

--- a/examples/AdafruitHuzzahESP8266_SSL/AdafruitHuzzahESP8266_SSL.ino
+++ b/examples/AdafruitHuzzahESP8266_SSL/AdafruitHuzzahESP8266_SSL.ino
@@ -8,7 +8,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <ESP8266WiFi.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char ssid[] = "ssid";
 const char pass[] = "pass";

--- a/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
+++ b/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
@@ -8,7 +8,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <Ethernet.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 byte mac[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED};
 byte ip[] = {192, 168, 1, 177};  // <- change to match your network

--- a/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
+++ b/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
@@ -10,7 +10,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <MKRGSM.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char pin[]      = "";
 const char apn[]      = "apn";

--- a/examples/ArduinoMKRGSM1400_SSL/ArduinoMKRGSM1400_SSL.ino
+++ b/examples/ArduinoMKRGSM1400_SSL/ArduinoMKRGSM1400_SSL.ino
@@ -10,7 +10,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <MKRGSM.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char pin[]      = "";
 const char apn[]      = "apn";

--- a/examples/ArduinoWiFi101/ArduinoWiFi101.ino
+++ b/examples/ArduinoWiFi101/ArduinoWiFi101.ino
@@ -10,7 +10,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <WiFi101.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char ssid[] = "ssid";
 const char pass[] = "pass";

--- a/examples/ArduinoWiFi101_SSL/ArduinoWiFi101_SSL.ino
+++ b/examples/ArduinoWiFi101_SSL/ArduinoWiFi101_SSL.ino
@@ -13,7 +13,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <WiFi101.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char ssid[] = "ssid";
 const char pass[] = "pass";

--- a/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
+++ b/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
@@ -8,7 +8,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <WiFi.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char ssid[] = "ssid";
 const char pass[] = "pass";

--- a/examples/ArduinoYun/ArduinoYun.ino
+++ b/examples/ArduinoYun/ArduinoYun.ino
@@ -9,7 +9,7 @@
 
 #include <Bridge.h>
 #include <BridgeClient.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 BridgeClient net;
 MQTTClient client;

--- a/examples/ArduinoYun_SSL/ArduinoYun_SSL.ino
+++ b/examples/ArduinoYun_SSL/ArduinoYun_SSL.ino
@@ -9,7 +9,7 @@
 
 #include <Bridge.h>
 #include <BridgeSSLClient.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 BridgeSSLClient net;
 MQTTClient client;

--- a/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
+++ b/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
@@ -8,7 +8,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <WiFi.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char ssid[] = "ssid";
 const char pass[] = "pass";

--- a/examples/ESP32DevelopmentBoard_SSL/ESP32DevelopmentBoard_SSL.ino
+++ b/examples/ESP32DevelopmentBoard_SSL/ESP32DevelopmentBoard_SSL.ino
@@ -8,7 +8,7 @@
 // https://github.com/256dpi/arduino-mqtt
 
 #include <WiFiClientSecure.h>
-#include <MQTTClient.h>
+#include <MQTT.h>
 
 const char ssid[] = "ssid";
 const char pass[] = "pass";

--- a/src/MQTT.h
+++ b/src/MQTT.h
@@ -1,0 +1,6 @@
+#ifndef MQTT_H
+#define MQTT_H
+
+#include "MQTTClient.h"
+
+#endif


### PR DESCRIPTION
Since the `name` value in `library.properties` is "MQTT", this library should have main include header of `MQTT.h` to avoid conflicts with other libraries that contain a `MQTTClient.h` file.

On Arduino Create we are having a conflict with the following library: https://bitbucket.org/amotzek/arduino/src/fab21e1e7785fe9473d83107048d4431c8fd25a9/src/main/cpp/MQTTClient/

This proposal resolves the conflict, and is still backwards compatible with existing sketches that include `MQTTClient.h`.

cc/ @matteosuppo