### PR TITLE
Document that `setWill()` only works if it is called before `connect()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ void setHost(const char hostname[]);
 void setHost(const char hostname[], int port);
 ```
 
-Set a will message (last testament) that gets registered on the broker after connecting:
+Set a will message (last testament) that gets registered on the broker after connecting. `setWill()` has to be called before calling `connect()`:
 
 ```c++
 void setWill(const char topic[]);


### PR DESCRIPTION
I noticed that it only works if `setWill()` is called before establishing the connection. This PR documents this behavior in the README.