### PR TITLE
Fixed the username and password flags to be compliance with the standard

### DIFF
--- a/src/lwmqtt/packet.c
+++ b/src/lwmqtt/packet.c
@@ -132,11 +132,11 @@ lwmqtt_err_t lwmqtt_encode_connect(uint8_t *buf, size_t buf_len, size_t *len, lw
 
   // set username flag if present
   if (options.username.len > 0) {
-    lwmqtt_write_bits(&flags, 1, 6, 1);
+    lwmqtt_write_bits(&flags, 1, 7, 1);
 
     // set password flag if present
     if (options.password.len > 0) {
-      lwmqtt_write_bits(&flags, 1, 7, 1);
+      lwmqtt_write_bits(&flags, 1, 6, 1);
     }
   }
 


### PR DESCRIPTION
Hello Joël,

I found out the flags of username and password are wrong and don't follow the standard [3.1.2.3 Connect Flags](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349229)
https://github.com/256dpi/arduino-mqtt/blob/26fd2df606cb0e1e992a1b98be4124cfa315ddb0/src/lwmqtt/packet.c#L135

Could you merge this pull request in the next release?
Thank you
