### PR TITLE
[WIP] Secure Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,12 @@ void setOptions(int keepAlive, bool cleanSession, int timeout);
 Connect to broker using the supplied client id and an optional username and password:
 
 ```c++
-bool connect(const char clientId[]);
-bool connect(const char clientId[], const char username[]);
-bool connect(const char clientId[], const char username[], const char password[]);
+bool connect(const char clientId[], bool skip = false);
+bool connect(const char clientId[], const char username[], bool skip = false);
+bool connect(const char clientId[], const char username[], const char password[], bool skip = false);
 ```
 
+- If the `skip` option is set to true, the client skip the network level connection and continue with the MQTT level connection. This option should can be used in order to establish and verify TLS connections. 
 - This functions returns a boolean that indicates if the connection has been established successfully.
 
 Publishes a message to the broker with an optional payload:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ bool connect(const char clientId[], const char username[], bool skip = false);
 bool connect(const char clientId[], const char username[], const char password[], bool skip = false);
 ```
 
-- If the `skip` option is set to true, the client will skip the network level connection and jump to the MQTT level connection. This option should can be used in order to establish and verify TLS connections manually before giving control to the MQTT client. 
+- If the `skip` option is set to true, the client will skip the network level connection and jump to the MQTT level connection. This option can be used in order to establish and verify TLS connections manually before giving control to the MQTT client. 
 - This functions returns a boolean that indicates if the connection has been established successfully.
 
 Publishes a message to the broker with an optional payload:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ bool connect(const char clientId[], const char username[], bool skip = false);
 bool connect(const char clientId[], const char username[], const char password[], bool skip = false);
 ```
 
-- If the `skip` option is set to true, the client skip the network level connection and continue with the MQTT level connection. This option should can be used in order to establish and verify TLS connections. 
+- If the `skip` option is set to true, the client will skip the network level connection and jump to the MQTT level connection. This option should can be used in order to establish and verify TLS connections manually before giving control to the MQTT client. 
 - This functions returns a boolean that indicates if the connection has been established successfully.
 
 Publishes a message to the broker with an optional payload:

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -273,22 +273,25 @@ class MQTTClient {
     this->timeout = (uint32_t)timeout;
   }
 
-  bool connect(const char clientId[]) { return this->connect(clientId, nullptr, nullptr); }
+  bool connect(const char clientId[], bool skip = false) { return this->connect(clientId, nullptr, nullptr); }
 
-  bool connect(const char clientId[], const char username[]) { return this->connect(clientId, username, nullptr); }
+  bool connect(const char clientId[], const char username[], bool skip = false) { return this->connect(clientId, username, nullptr); }
 
-  bool connect(const char clientId[], const char username[], const char password[]) {
+  bool connect(const char clientId[], const char username[], const char password[], bool skip = false) {
     // close left open connection if still connected
-    if (this->connected()) {
+    if (!skip && this->connected()) {
       this->close();
     }
 
     // save client
     this->network.client = this->netClient;
 
-    // connect to host
-    if (this->netClient->connect(this->hostname, (uint16_t)this->port) <= 0) {
-      return false;
+    // connect to hostg
+    if(!skip) {
+      int ret = this->netClient->connect(this->hostname, (uint16_t)this->port);
+      if (ret <= 0) {
+        return false;
+      }
     }
 
     // prepare options


### PR DESCRIPTION
This PR adds the option `skip` to `connect`. This allows secure connections to be established and verified outside of the library. This is necessary as there is not yet a standardized way of verifying TLS connections in Arduino.