### PR TITLE
Update ESP8266 FQBN in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ env:
   global:
     - IDE_VERSION=1.8.7
   matrix:
-    - EXAMPLE="AdafruitHuzzahESP8266" BOARD="esp8266:esp8266:huzzah:FlashSize=4M3M,CpuFrequency=80"
-    - EXAMPLE="AdafruitHuzzahESP8266Secure" BOARD="esp8266:esp8266:huzzah:FlashSize=4M3M,CpuFrequency=80"
+    - EXAMPLE="AdafruitHuzzahESP8266" BOARD="esp8266:esp8266:huzzah:eesz=4M3M,xtal=80"
+    - EXAMPLE="AdafruitHuzzahESP8266Secure" BOARD="esp8266:esp8266:huzzah:eesz=4M3M,xtal=80"
     - EXAMPLE="ArduinoEthernetShield" BOARD="arduino:avr:uno"
     - EXAMPLE="ArduinoMKRGSM1400" BOARD="arduino:samd:mkrgsm1400"
     - EXAMPLE="ArduinoMKRGSM1400Secure" BOARD="arduino:samd:mkrgsm1400"


### PR DESCRIPTION
Some of the menu IDs for the ESP8266 boards were recently changed (https://github.com/esp8266/Arduino/issues/5572), which caused compilation in the Travis CI build to fail with "Invalid option for board" error.