### PR TITLE
Pass skip parameter in connect calls

### DIFF
--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -270,9 +270,9 @@ class MQTTClient {
     this->timeout = (uint32_t)timeout;
   }
 
-  bool connect(const char clientId[], bool skip = false) { return this->connect(clientId, nullptr, nullptr); }
+  bool connect(const char clientId[], bool skip = false) { return this->connect(clientId, nullptr, nullptr, skip); }
 
-  bool connect(const char clientId[], const char username[], bool skip = false) { return this->connect(clientId, username, nullptr); }
+  bool connect(const char clientId[], const char username[], bool skip = false) { return this->connect(clientId, username, nullptr, skip); }
 
   bool connect(const char clientId[], const char username[], const char password[], bool skip = false) {
     // close left open connection if still connected


### PR DESCRIPTION
Simplified connect methods have `skip` parameter but it is not passed further into full connect method.

```
bool connect(const char clientId[], bool skip = false);
bool connect(const char clientId[], const char username[], bool skip = false);
```

This PR fixes the issue by passing skip param further.