### PR TITLE
last error set appropriately when socket connection is not established 

### DIFF
--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -261,6 +261,7 @@ bool MQTTClient::connect(const char clientId[], const char username[], const cha
     int ret = this->netClient->connect(this->hostname, (uint16_t)this->port);
     if (ret <= 0) {
       return false;
+      this->_lastError = LWMQTT_NETWORK_FAILED_CONNECT;
     }
   }
 

--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -260,8 +260,8 @@ bool MQTTClient::connect(const char clientId[], const char username[], const cha
   if (!skip) {
     int ret = this->netClient->connect(this->hostname, (uint16_t)this->port);
     if (ret <= 0) {
-      return false;
       this->_lastError = LWMQTT_NETWORK_FAILED_CONNECT;
+      return false;
     }
   }
 

--- a/src/lwmqtt/client.c
+++ b/src/lwmqtt/client.c
@@ -357,8 +357,8 @@ lwmqtt_err_t lwmqtt_connect(lwmqtt_client_t *client, lwmqtt_options_t options, l
   // set command timer
   client->timer_set(client->command_timer, timeout);
 
-  // save keep alive interval (take 75% to be a little earlier than actually needed)
-  client->keep_alive_interval = (uint32_t)(options.keep_alive) * 750;
+  // save keep alive interval
+  client->keep_alive_interval = (uint32_t)(options.keep_alive) * 1000;
 
   // set keep alive timer
   client->timer_set(client->keep_alive_timer, client->keep_alive_interval);


### PR DESCRIPTION
last error set to LWMQTT_NETWORK_FAILED_CONNECT for socket connection failures.