### PR TITLE
Added lambda feature for onMessage callback. Fixes #147

### DIFF
--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -115,11 +115,13 @@ static void MQTTClientHandler(lwmqtt_client_t * /*client*/, void *ref, lwmqtt_st
     str_payload = String((const char *)message.payload);
   }
 
+#if has_functional
   // call the lambda callback and return if available
   if (cb->lambda != nullptr) {
     cb->lambda(str_topic, str_payload);
     return;
   }
+#endif
 
   // call simple callback
   cb->simple(str_topic, str_payload);
@@ -169,13 +171,15 @@ void MQTTClient::begin(const char _hostname[], int _port, Client &_client) {
   lwmqtt_set_callback(&this->client, (void *)&this->callback, MQTTClientHandler);
 }
 
-void MQTTClient::onMessage(MQTTClientCallbackLambda cb) {
+#if has_functional
+void MQTTClient::onMessage(MQTTClientCallbackSimpleLambda cb) {
   // set callback
   this->callback.client = this;
   this->callback.simple = nullptr;
   this->callback.lambda = cb;
   this->callback.advanced = nullptr;
 }
+#endif
 
 void MQTTClient::onMessage(MQTTClientCallbackSimple cb) {
   // set callback

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <Client.h>
 #include <Stream.h>
+#include <functional>
 
 extern "C" {
 #include "lwmqtt/lwmqtt.h"
@@ -22,6 +23,7 @@ typedef struct {
 
 class MQTTClient;
 
+typedef std::function<void(String&, String&)> MQTTClientCallbackLambda;
 typedef void (*MQTTClientCallbackSimple)(String &topic, String &payload);
 typedef void (*MQTTClientCallbackAdvanced)(MQTTClient *client, char topic[], char bytes[], int length);
 
@@ -29,6 +31,7 @@ typedef struct {
   MQTTClient *client = nullptr;
   MQTTClientCallbackSimple simple = nullptr;
   MQTTClientCallbackAdvanced advanced = nullptr;
+  MQTTClientCallbackLambda lambda = nullptr;
 } MQTTClientCallback;
 
 class MQTTClient {
@@ -66,6 +69,7 @@ class MQTTClient {
   void begin(const char _hostname[], Client &_client) { this->begin(_hostname, 1883, _client); }
   void begin(const char hostname[], int port, Client &client);
 
+  void onMessage(MQTTClientCallbackLambda cb);
   void onMessage(MQTTClientCallbackSimple cb);
   void onMessageAdvanced(MQTTClientCallbackAdvanced cb);
 


### PR DESCRIPTION
It allows the use of lambdas to access class reference. For example.

`
client.onMessage( [this] (String &topic, String &payload) {
  Serial.println("Member Variable: " + String(this->myVar));
  Serial.println("incoming: " + topic + " - " + payload);
});
`