### PR TITLE
Fixes #197 - by publishing blank retained message to topic before sub

### DIFF
--- a/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
+++ b/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
@@ -33,6 +33,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
+++ b/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
@@ -33,13 +33,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/AdafruitHuzzahESP8266Secure/AdafruitHuzzahESP8266Secure.ino
+++ b/examples/AdafruitHuzzahESP8266Secure/AdafruitHuzzahESP8266Secure.ino
@@ -38,13 +38,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/AdafruitHuzzahESP8266Secure/AdafruitHuzzahESP8266Secure.ino
+++ b/examples/AdafruitHuzzahESP8266Secure/AdafruitHuzzahESP8266Secure.ino
@@ -38,6 +38,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
+++ b/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
@@ -27,6 +27,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
+++ b/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
@@ -27,13 +27,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
+++ b/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
@@ -50,6 +50,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
+++ b/examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
@@ -50,13 +50,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoMKRGSM1400Secure/ArduinoMKRGSM1400Secure.ino
+++ b/examples/ArduinoMKRGSM1400Secure/ArduinoMKRGSM1400Secure.ino
@@ -50,6 +50,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoMKRGSM1400Secure/ArduinoMKRGSM1400Secure.ino
+++ b/examples/ArduinoMKRGSM1400Secure/ArduinoMKRGSM1400Secure.ino
@@ -50,13 +50,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoWiFi101/ArduinoWiFi101.ino
+++ b/examples/ArduinoWiFi101/ArduinoWiFi101.ino
@@ -35,13 +35,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoWiFi101/ArduinoWiFi101.ino
+++ b/examples/ArduinoWiFi101/ArduinoWiFi101.ino
@@ -35,6 +35,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoWiFi101Secure/ArduinoWiFi101Secure.ino
+++ b/examples/ArduinoWiFi101Secure/ArduinoWiFi101Secure.ino
@@ -38,13 +38,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoWiFi101Secure/ArduinoWiFi101Secure.ino
+++ b/examples/ArduinoWiFi101Secure/ArduinoWiFi101Secure.ino
@@ -38,6 +38,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
+++ b/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
@@ -33,6 +33,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
+++ b/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
@@ -33,13 +33,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoYun/ArduinoYun.ino
+++ b/examples/ArduinoYun/ArduinoYun.ino
@@ -25,13 +25,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoYun/ArduinoYun.ino
+++ b/examples/ArduinoYun/ArduinoYun.ino
@@ -25,6 +25,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ArduinoYunSecure/ArduinoYunSecure.ino
+++ b/examples/ArduinoYunSecure/ArduinoYunSecure.ino
@@ -25,13 +25,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ArduinoYunSecure/ArduinoYunSecure.ino
+++ b/examples/ArduinoYunSecure/ArduinoYunSecure.ino
@@ -25,6 +25,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
+++ b/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
@@ -33,6 +33,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
+++ b/examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
@@ -33,13 +33,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");

--- a/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
+++ b/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
@@ -33,6 +33,14 @@ void connect() {
 
   Serial.println("\nconnected!");
 
+  // Publish a blank retained message in order to prevent us receiving large
+  // retained messages that have been published by others. Large retained
+  // messages can result in overflowing the ardiuno-mqtt client's default
+  // buffer size. If a large retained message is still being set, then it may
+  // still glitch this program if that message is published between this
+  // retained message and the subscription to the topic.
+  // Then, subscribe to the same topic
+  client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");
 }

--- a/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
+++ b/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
@@ -33,13 +33,7 @@ void connect() {
 
   Serial.println("\nconnected!");
 
-  // Publish a blank retained message in order to prevent us receiving large
-  // retained messages that have been published by others. Large retained
-  // messages can result in overflowing the ardiuno-mqtt client's default
-  // buffer size. If a large retained message is still being set, then it may
-  // still glitch this program if that message is published between this
-  // retained message and the subscription to the topic.
-  // Then, subscribe to the same topic
+  // Clear retained messages that may have been published earlier on this topic.
   client.publish("/hello", "", 1, true);
   client.subscribe("/hello");
   // client.unsubscribe("/hello");


### PR DESCRIPTION
Fixes #197 by adding the publication of a blank retained message immediately before subscribing to the topic.

There's still a possibility of crashing due to a race between the publishing of the retained message and the subscription to the topic. Another source might have published a large retained message between our publish and subscribe commands.

There is commentary to suit. All examples have been updated.