### PR TITLE
update lwmqtt_client_t initialization

### DIFF
--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -120,9 +120,6 @@ static void MQTTClientHandler(lwmqtt_client_t * /*client*/, void *ref, lwmqtt_st
 }
 
 MQTTClient::MQTTClient(int bufSize) {
-  // reset client
-  memset(&this->client, 0, sizeof(lwmqtt_client_t));
-
   // allocate buffers
   this->bufSize = (size_t)bufSize;
   this->readBuf = (uint8_t *)malloc((size_t)bufSize + 1);

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -50,7 +50,7 @@ class MQTTClient {
   lwmqtt_arduino_network_t network = {nullptr};
   lwmqtt_arduino_timer_t timer1 = {0, nullptr};
   lwmqtt_arduino_timer_t timer2 = {0, nullptr};
-  lwmqtt_client_t client = {0};
+  lwmqtt_client_t client = lwmqtt_client_t();
 
   bool _connected = false;
   lwmqtt_return_code_t _returnCode = (lwmqtt_return_code_t)0;


### PR DESCRIPTION
to avoid

> In file included from [cut]\Arduino\libraries\MQTT\src\MQTTClient.cpp:1:0:
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::keep_alive_interval' [-Wmissing-field-initializers]
>    lwmqtt_client_t client = {0};
>                               ^
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::pong_pending' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::write_buf_size' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::read_buf_size' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::write_buf' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::read_buf' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::callback' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::callback_ref' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::network' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::network_read' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::network_write' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::keep_alive_timer' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::command_timer' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::timer_set' [-Wmissing-field-initializers]
> Arduino\libraries\MQTT\src\MQTTClient.h:53:30: warning: missing initializer for member 'lwmqtt_client_t::timer_get' [-Wmissing-field-initializers]
> 