### PR TITLE
Support IPAddresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ void loop() {
 Initialize the object using the hostname of the broker, the brokers port (default: `1883`) and the underlying Client class for network transport:
 
 ```c++
+void begin(Client &client);
 void begin(const char hostname[], Client &client);
 void begin(const char hostname[], int port, Client &client);
+void begin(IPAddress address, Client &client);
+void begin(IPAddress address, int port, Client &client);
 ```
 
 - Specify port `8883` when using secure clients for encrypted connections.
@@ -122,6 +125,8 @@ The hostname and port can also be changed after calling `begin()`:
 ```c++
 void setHost(const char hostname[]);
 void setHost(const char hostname[], int port);
+void setHost(IPAddress address);
+void setHost(IPAddress address, int port);
 ```
 
 Set a will message (last testament) that gets registered on the broker after connecting. `setWill()` has to be called before calling `connect()`:
@@ -171,9 +176,9 @@ void setClockSource(MQTTClientClockSource);
 Connect to broker using the supplied client id and an optional username and password:
 
 ```c++
-bool connect(const char clientId[], bool skip = false);
-bool connect(const char clientId[], const char username[], bool skip = false);
-bool connect(const char clientId[], const char username[], const char password[], bool skip = false);
+bool connect(const char clientID[], bool skip = false);
+bool connect(const char clientID[], const char username[], bool skip = false);
+bool connect(const char clientID[], const char username[], const char password[], bool skip = false);
 ```
 
 - If the `skip` option is set to true, the client will skip the network level connection and jump to the MQTT level connection. This option can be used in order to establish and verify TLS connections manually before giving control to the MQTT client. 

--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -206,15 +206,15 @@ void MQTTClient::setHost(IPAddress ipAddr, int port) {
   this->port = port;
 }
 
-void MQTTClient::setHost(const char hostname[], int port) {
+void MQTTClient::setHost(const char _hostname[], int _port) {
   // free hostname if set
   if (this->hostname != nullptr) {
     free((void *)this->hostname);
   }
 
   // set hostname and port
-  this->hostname = strdup(hostname);
-  this->port = port;
+  this->hostname = strdup(_hostname);
+  this->port = _port;
 }
 
 void MQTTClient::setWill(const char topic[], const char payload[], bool retained, int qos) {

--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -246,12 +246,6 @@ void MQTTClient::setCleanSession(bool _cleanSession) { this->cleanSession = _cle
 
 void MQTTClient::setTimeout(int _timeout) { this->timeout = _timeout; }
 
-void MQTTClient::setOptions(int _keepAlive, bool _cleanSession, int _timeout) {
-  this->setKeepAlive(_keepAlive);
-  this->setCleanSession(_cleanSession);
-  this->setTimeout(_timeout);
-}
-
 bool MQTTClient::publish(const char topic[], const char payload[], int length, bool retained, int qos) {
   // return immediately if not connected
   if (!this->connected()) {

--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -143,27 +143,18 @@ MQTTClient::~MQTTClient() {
 void MQTTClient::begin(IPAddress ipAddr, int port, Client &client) {
   // set hostname and port
   this->setHost(ipAddr, port);
-
-  // set client
-  this->netClient = &client;
-
-  // initialize client
-  lwmqtt_init(&this->client, this->writeBuf, this->bufSize, this->readBuf, this->bufSize);
-
-  // set timers
-  lwmqtt_set_timers(&this->client, &this->timer1, &this->timer2, lwmqtt_arduino_timer_set, lwmqtt_arduino_timer_get);
-
-  // set network
-  lwmqtt_set_network(&this->client, &this->network, lwmqtt_arduino_network_read, lwmqtt_arduino_network_write);
-
-  // set callback
-  lwmqtt_set_callback(&this->client, (void *)&this->callback, MQTTClientHandler);
+  // finish up begin() call
+  _begin(port, client);
 }
 
 void MQTTClient::begin(const char hostname[], int port, Client &client) {
   // set hostname and port
   this->setHost(hostname, port);
+  // finish up begin() call
+  _begin(port, client);
+}
 
+void MQTTClient::_begin(int port, Client &client){
   // set client
   this->netClient = &client;
 
@@ -199,11 +190,11 @@ void MQTTClient::setClockSource(MQTTClientClockSource cb) {
   this->timer2.millis = cb;
 }
 
-void MQTTClient::setHost(IPAddress ipAddr, int port) {
+void MQTTClient::setHost(IPAddress _ipAddr, int _port) {
   // set hostname and port
-  this->ipaddress = ipAddr;
+  this->ipaddress = _ipAddr;
   
-  this->port = port;
+  this->port = _port;
 }
 
 void MQTTClient::setHost(const char _hostname[], int _port) {
@@ -316,13 +307,7 @@ bool MQTTClient::connect(const char clientId[], const char username[], const cha
 	if(this->hostname != nullptr){
 	  ret = this->netClient->connect(this->hostname, (uint16_t)this->port);
 	}else{
-	  uint32_t thisIP = 0;
-	  thisIP = ipaddress[0];
-	  thisIP |= uint32_t(ipaddress[1] << 8);
-	  thisIP |= uint32_t(ipaddress[2] << 16);
-	  thisIP |= uint32_t(ipaddress[3] << 24);
-	  
-	  ret = this->netClient->connect(thisIP, (uint16_t)this->port);
+	  ret = this->netClient->connect(this->ipaddress, (uint16_t)this->port);
 	}
 	
     if (ret <= 0) {

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -136,6 +136,7 @@ class MQTTClient {
 
  private:
   void close();
+  void _begin(int port, Client &client);
 };
 
 #endif

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -43,6 +43,7 @@ class MQTTClient {
 
   Client *netClient = nullptr;
   const char *hostname = nullptr;
+  IPAddress ipaddress;
   int port = 0;
   lwmqtt_will_t *will = nullptr;
   MQTTClientCallback callback;
@@ -65,6 +66,9 @@ class MQTTClient {
 
   void begin(const char _hostname[], Client &_client) { this->begin(_hostname, 1883, _client); }
   void begin(const char hostname[], int port, Client &client);
+  
+  void begin(IPAddress _ipAddr, Client &client) { this->begin(_ipAddr, 1883, client); }
+  void begin(IPAddress ipAddr, int port, Client &client);
 
   void onMessage(MQTTClientCallbackSimple cb);
   void onMessageAdvanced(MQTTClientCallbackAdvanced cb);
@@ -73,6 +77,9 @@ class MQTTClient {
 
   void setHost(const char _hostname[]) { this->setHost(_hostname, 1883); }
   void setHost(const char hostname[], int port);
+  
+  void setHost(IPAddress _ipAddr) { this->setHost(_ipAddr, 1883); }
+  void setHost(IPAddress ipAddr, int port);
 
   void setWill(const char topic[]) { this->setWill(topic, ""); }
   void setWill(const char topic[], const char payload[]) { this->setWill(topic, payload, false, 0); }

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -43,7 +43,7 @@ class MQTTClient {
 
   Client *netClient = nullptr;
   const char *hostname = nullptr;
-  IPAddress ipaddress;
+  IPAddress address;
   int port = 0;
   lwmqtt_will_t *will = nullptr;
   MQTTClientCallback callback;
@@ -64,11 +64,17 @@ class MQTTClient {
 
   ~MQTTClient();
 
+  void begin(Client &_client);
   void begin(const char _hostname[], Client &_client) { this->begin(_hostname, 1883, _client); }
-  void begin(const char hostname[], int port, Client &client);
-  
-  void begin(IPAddress _ipAddr, Client &client) { this->begin(_ipAddr, 1883, client); }
-  void begin(IPAddress ipAddr, int port, Client &client);
+  void begin(const char _hostname[], int _port, Client &_client) {
+    this->begin(_client);
+    this->setHost(_hostname, _port);
+  }
+  void begin(IPAddress _address, Client &_client) { this->begin(_address, 1883, _client); }
+  void begin(IPAddress _address, int _port, Client &_client) {
+    this->begin(_client);
+    this->setHost(_address, _port);
+  }
 
   void onMessage(MQTTClientCallbackSimple cb);
   void onMessageAdvanced(MQTTClientCallbackAdvanced cb);
@@ -77,9 +83,8 @@ class MQTTClient {
 
   void setHost(const char _hostname[]) { this->setHost(_hostname, 1883); }
   void setHost(const char hostname[], int port);
-  
-  void setHost(IPAddress _ipAddr) { this->setHost(_ipAddr, 1883); }
-  void setHost(IPAddress ipAddr, int port);
+  void setHost(IPAddress _address) { this->setHost(_address, 1883); }
+  void setHost(IPAddress _address, int port);
 
   void setWill(const char topic[]) { this->setWill(topic, ""); }
   void setWill(const char topic[], const char payload[]) { this->setWill(topic, payload, false, 0); }
@@ -95,7 +100,7 @@ class MQTTClient {
   bool connect(const char clientId[], const char username[], bool skip = false) {
     return this->connect(clientId, username, nullptr, skip);
   }
-  bool connect(const char clientId[], const char username[], const char password[], bool skip = false);
+  bool connect(const char clientID[], const char username[], const char password[], bool skip = false);
 
   bool publish(const String &topic) { return this->publish(topic.c_str(), ""); }
   bool publish(const char topic[]) { return this->publish(topic, ""); }
@@ -136,7 +141,6 @@ class MQTTClient {
 
  private:
   void close();
-  void _begin(int port, Client &client);
 };
 
 #endif

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -94,7 +94,12 @@ class MQTTClient {
   void setKeepAlive(int keepAlive);
   void setCleanSession(bool cleanSession);
   void setTimeout(int timeout);
-  void setOptions(int keepAlive, bool cleanSession, int timeout);
+
+  void setOptions(int _keepAlive, bool _cleanSession, int _timeout) {
+    this->setKeepAlive(_keepAlive);
+    this->setCleanSession(_cleanSession);
+    this->setTimeout(_timeout);
+  }
 
   bool connect(const char clientId[], bool skip = false) { return this->connect(clientId, nullptr, nullptr, skip); }
   bool connect(const char clientId[], const char username[], bool skip = false) {


### PR DESCRIPTION
- Instead of using hostname and DNS lookups, use IPAddress to remove need for UDP when used with software IP stacks. Saves program space and memory.
ie: [UIPEthernet](https://github.com/UIPEthernet/UIPEthernet) or [RF24Ethernet](https://github.com/nRF24/RF24Ethernet) libraries