### PR TITLE
Update README for new reference of line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ lwmqtt_err_t lastError();
 lwmqtt_return_code_t returnCode();
 ```
 
-- The error codes can be found [here](https://github.com/256dpi/lwmqtt/blob/master/include/lwmqtt.h#L11).
-- The return codes can be found [here](https://github.com/256dpi/lwmqtt/blob/master/include/lwmqtt.h#L243).
+- The error codes can be found [here](https://github.com/256dpi/lwmqtt/blob/master/include/lwmqtt.h#L15).
+- The return codes can be found [here](https://github.com/256dpi/lwmqtt/blob/master/include/lwmqtt.h#L260).
 
 Disconnect from the broker:
 


### PR DESCRIPTION
Error codes and return codes were referenced incorrectly (probably due to changes in the referenced file). I have updated those to refer to the correct line numbers.