### PR TITLE
Include functional API also for the ESP32.

### DIFF
--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -3,7 +3,7 @@
 
 // include functional API if possible. remove min and max macros for some
 // platforms as they will be defined again by Arduino later
-#if defined(ESP8266)
+#if defined(ESP8266) || (defined ESP32)
 #include <functional>
 #define MQTT_HAS_FUNCTIONAL 1
 #elif defined(__has_include)


### PR DESCRIPTION
The functional API should be also supported for the ESP32.

This PR adds the `#include <functional>` directive also for the ESP32.
