### PR TITLE
Fix esp32 TCP connection by skipping verification

### DIFF
--- a/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
+++ b/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
@@ -26,6 +26,7 @@ void connect() {
   }
 
   Serial.print("\nconnecting...");
+  net.setInsecure();
   while (!client.connect("arduino", "public", "public")) {
     Serial.print(".");
     delay(1000);

--- a/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
+++ b/examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
@@ -26,6 +26,9 @@ void connect() {
   }
 
   Serial.print("\nconnecting...");
+  // do not verify tls certificate
+  // check the following example for methods to verify the server:
+  // https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFiClientSecure/examples/WiFiClientSecure/WiFiClientSecure.ino
   net.setInsecure();
   while (!client.connect("arduino", "public", "public")) {
     Serial.print(".");


### PR DESCRIPTION
ESP32DevelopmentBoardSecure example couldn't connect to shiftr.io.
This turns off certificate and/or fingerprint verification same as AdafruitHuzzahESP8266Secure example.