### PR TITLE
Add missing strdup implementation for Arduino Uno R4-WiFi

### DIFF
--- a/src/MQTTClient.cpp
+++ b/src/MQTTClient.cpp
@@ -1,6 +1,6 @@
 #include "MQTTClient.h"
 
-#ifdef ARDUINO_UNOR4_WIFI
+#if defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
 
 inline char *strdup(const char *dup) {
   size_t len = strlen(dup) + 1;


### PR DESCRIPTION
Implements missing "strdup" function in case of Arduino Uno R4 WiFi.
Possible solution for https://github.com/256dpi/arduino-mqtt/issues/307.