### PR TITLE
fix(typo): change variable name according to implementation

### DIFF
--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -97,7 +97,7 @@ class MQTTClient {
   void *ref = nullptr;
 
   explicit MQTTClient(int bufSize = 128) : MQTTClient(bufSize, bufSize) {}
-  MQTTClient(int readSize, int writeBufSize);
+  MQTTClient(int readBufSize, int writeBufSize);
 
   ~MQTTClient();
 


### PR DESCRIPTION
Var name as https://github.com/256dpi/arduino-mqtt/blob/77bd41d4095787152f8aa8384dd6ed376ac6d605/src/MQTTClient.cpp#L161