### PR TITLE
add support for installing via idf component manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,51 @@
 # Uncompilable CMake File to enable project editing with CLion IDE
 
 cmake_minimum_required(VERSION 3.13)
-project(arduino-mqtt)
 
-include_directories(
-        /Applications/Arduino.app/Contents/Java/hardware/arduino/avr/cores/arduino
-        /Users/256dpi/Documents/Arduino/libraries/Ethernet/src
-        /Users/256dpi/Documents/Arduino/libraries/WiFi101/src
-        /Users/256dpi/Documents/Arduino/libraries/MKRGSM/src
-        /Users/256dpi/Documents/Arduino/libraries/MKRNB/src
-        /Applications/Arduino.app/Contents/Java/libraries/Bridge/src
-        /Users/256dpi/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi/src
-        /Users/256dpi/Library/Arduino15/packages/esp32/hardware/esp32/2.0.11/libraries/WiFi/src
-        /Users/256dpi/Library/Arduino15/packages/esp32/hardware/esp32/2.0.11/libraries/WiFiClientSecure/src
-        src)
+if(COMMAND idf_component_register)
+    file(GLOB SRCS "src/*.cpp" "src/lwmqtt/*.c")
 
-include_directories(src/)
+    idf_component_register(
+        SRCS ${SRCS}
+        INCLUDE_DIRS "src" "src/lwmqtt"
+    )
+else()
+    project(arduino-mqtt)
 
-set(CMAKE_CXX_FLAGS -std=c++11)
+    include_directories(
+            /Applications/Arduino.app/Contents/Java/hardware/arduino/avr/cores/arduino
+            /Users/256dpi/Documents/Arduino/libraries/Ethernet/src
+            /Users/256dpi/Documents/Arduino/libraries/WiFi101/src
+            /Users/256dpi/Documents/Arduino/libraries/MKRGSM/src
+            /Users/256dpi/Documents/Arduino/libraries/MKRNB/src
+            /Applications/Arduino.app/Contents/Java/libraries/Bridge/src
+            /Users/256dpi/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi/src
+            /Users/256dpi/Library/Arduino15/packages/esp32/hardware/esp32/2.0.11/libraries/WiFi/src
+            /Users/256dpi/Library/Arduino15/packages/esp32/hardware/esp32/2.0.11/libraries/WiFiClientSecure/src
+            src)
 
-set(SOURCE_FILES
-    examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
-        examples/AdafruitHuzzahESP8266Secure/AdafruitHuzzahESP8266Secure.ino
-    examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
-    examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
-        examples/ArduinoMKRGSM1400Secure/ArduinoMKRGSM1400Secure.ino
-    examples/ArduinoMKRNB1500/ArduinoMKRNB1500.ino
-    examples/ArduinoWiFi101/ArduinoWiFi101.ino
-        examples/ArduinoWiFi101Secure/ArduinoWiFi101Secure.ino
-    examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
-    examples/ArduinoYun/ArduinoYun.ino
-        examples/ArduinoYunSecure/ArduinoYunSecure.ino
-    examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
-        examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
-    src/lwmqtt
-    src/MQTT.h
-    src/MQTTClient.h
-    src/MQTTClient.cpp)
+    include_directories(src/)
 
-add_executable(arduino-mqtt ${SOURCE_FILES})
+    set(CMAKE_CXX_FLAGS -std=c++11)
+
+    set(SOURCE_FILES
+        examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino
+            examples/AdafruitHuzzahESP8266Secure/AdafruitHuzzahESP8266Secure.ino
+        examples/ArduinoEthernetShield/ArduinoEthernetShield.ino
+        examples/ArduinoMKRGSM1400/ArduinoMKRGSM1400.ino
+            examples/ArduinoMKRGSM1400Secure/ArduinoMKRGSM1400Secure.ino
+        examples/ArduinoMKRNB1500/ArduinoMKRNB1500.ino
+        examples/ArduinoWiFi101/ArduinoWiFi101.ino
+            examples/ArduinoWiFi101Secure/ArduinoWiFi101Secure.ino
+        examples/ArduinoWiFiShield/ArduinoWiFiShield.ino
+        examples/ArduinoYun/ArduinoYun.ino
+            examples/ArduinoYunSecure/ArduinoYunSecure.ino
+        examples/ESP32DevelopmentBoard/ESP32DevelopmentBoard.ino
+            examples/ESP32DevelopmentBoardSecure/ESP32DevelopmentBoardSecure.ino
+        src/lwmqtt
+        src/MQTT.h
+        src/MQTTClient.h
+        src/MQTTClient.cpp)
+
+    add_executable(arduino-mqtt ${SOURCE_FILES})
+endif()

--- a/README.md
+++ b/README.md
@@ -5,16 +5,28 @@
 
 This library bundles the [lwmqtt](https://github.com/256dpi/lwmqtt) MQTT 3.1.1 client and adds a thin wrapper to get an Arduino like API.
 
-Download the latest version from the [release](https://github.com/256dpi/arduino-mqtt/releases) section. Or even better use the built-in Library Manager in the Arduino IDE and search for "lwmqtt".
+Download the latest version from the [release](https://github.com/256dpi/arduino-mqtt/releases) section.
 
-The library is also available on [PlatformIO](https://platformio.org/lib/show/617/MQTT). You can install it by running: `pio lib install "256dpi/MQTT"`. 
+Or it can be installed from the following library repositories:
+
+- Arduino IDE's Library Manager
+  - By searching for "lwmqtt".
+- [PlatformIO](https://platformio.org/lib/show/617/MQTT)
+  - By running `pio lib install "256dpi/MQTT"`.
+- [IDF Component Manager](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-component-manager.html)
+  - By adding it to `idf_component.yml`.
+```
+arduino_mqtt:
+  git: "https://github.com/256dpi/arduino-mqtt.git"
+  version: # tag, branch, or commit hash
+```
 
 ## Compatibility
 
 The following examples show how you can use the library with various Arduino compatible hardware:
 
 - [Arduino Yun & Yun-Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYun/ArduinoYun.ino) ([Secure](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoYunSecure/ArduinoYunSecure.ino))
-- [Arduino Ethernet Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino)    
+- [Arduino Ethernet Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoEthernetShield/ArduinoEthernetShield.ino)
 - [Arduino WiFi Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoWiFiShield/ArduinoWiFiShield.ino)
 - [Adafruit HUZZAH ESP8266](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266/AdafruitHuzzahESP8266.ino) ([Secure](https://github.com/256dpi/arduino-mqtt/blob/master/examples/AdafruitHuzzahESP8266Secure/AdafruitHuzzahESP8266Secure.ino))
 - [Arduino WiFi101 Shield](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoWiFi101/ArduinoWiFi101.ino) ([Secure](https://github.com/256dpi/arduino-mqtt/blob/master/examples/ArduinoWiFi101Secure/ArduinoWiFi101Secure.ino))
@@ -32,7 +44,7 @@ Other shields and boards should also work if they provide a [Client](https://www
 
 - On the ESP8266 it has been reported that an additional `delay(10);` after `client.loop();` fixes many stability issues with WiFi connections.
 
-- To use the library with shiftr.io, you need to provide the instance name (username) and token secret (password) as the second and third argument to `client.connect(client_id, username, password)`. 
+- To use the library with shiftr.io, you need to provide the instance name (username) and token secret (password) as the second and third argument to `client.connect(client_id, username, password)`.
 
 ## Example
 
@@ -201,7 +213,7 @@ bool connect(const char clientID[], const char username[], const char password[]
 ```
 
 - If `password` is present but `username` is absent, the client will fall back to an empty username.
-- If the `skip` option is set to true, the client will skip the network level connection and jump to the MQTT level connection. This option can be used in order to establish and verify TLS connections manually before giving control to the MQTT client. 
+- If the `skip` option is set to true, the client will skip the network level connection and jump to the MQTT level connection. This option can be used in order to establish and verify TLS connections manually before giving control to the MQTT client.
 - The functions return a boolean that indicates if the connection has been established successfully (true).
 
 Publish a message to the broker with an optional payload, which can be a string or binary:
@@ -237,7 +249,7 @@ Subscribe to a topic:
 
 ```c++
 bool subscribe(const String &topic);
-bool subscribe(const String &topic, int qos); 
+bool subscribe(const String &topic, int qos);
 bool subscribe(const char topic[]);
 bool subscribe(const char topic[], int qos);
 ```

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,9 @@
+dependencies:
+  espressif/arduino-esp32:
+    version: "^3.0.6"
+files:
+  include:
+    - "src/*.cpp"
+    - "src/*.h"
+    - "src/lwmqtt/*.c"
+    - "src/lwmqtt/*.h"


### PR DESCRIPTION
This change allows the library to be installed via Espressif's IDF Component Manager. It doesn't involve publishing it to the ESP Component Registry, but rather installing it via git.